### PR TITLE
feat(TR6): gh actions and release config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - "main"
+      - "TR6_adding_continuous_registry_deployment"
+  pull_request:
+
+jobs:
+  check-run:
+    name: Check PR run
+    uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
+
+  build:
+    name: Build
+    runs-on: ubuntu-24.04
+    needs: check-run
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install Go dependencies
+        run: go mod tidy
+
+      - name: Install build dependencies
+        run: sudo apt update && sudo apt install musl-tools -y
+
+      - name: Build binary
+        run: make build-linux-amd64
+
+      - name: Verify binary
+        run: make verify-binary-linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,136 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-pre"
+
+jobs:
+  check-run:
+    name: Check PR run
+    uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
+
+  build-artifact:
+    name: Build and verify artifact
+    runs-on: ${{ matrix.runner }}
+    needs: check-run
+    outputs:
+      module_name: ${{ steps.prepare-release.outputs.module_name }}
+      version: ${{ steps.prepare-release.outputs.version }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, darwin]
+        arch: [amd64, arm64]
+        include:
+          - os: ubuntu-24.04
+            arch: amd64
+            runner: ubuntu-24.04
+            build_target: build-linux-amd64
+            verify_target: verify-binary-linux
+            dependencies: musl-tools
+#          - os: ubuntu-24.04
+#            arch: arm64
+#            runner: ubuntu-24.04 # This should be the arm runner to enable native compilation
+#            build_target: build-linux-arm64
+#            verify-target: verify-binary-linux
+#            dependencies: gcc-aarch64-linux-gnu musl musl-dev musl-tools #This is not enough to enable cross-compilation
+          - os: darwin
+            arch: amd64
+            runner: macos-14
+            build_target: build-darwin-amd64
+            verify_target: verify-binary-darwin-amd64
+          - os: darwin
+            arch: arm64
+            runner: macos-14
+            build_target: build-darwin-arm64
+            verify_target: verify-binary-darwin-arm64
+        exclude:
+          - os: ubuntu-24.04 # We exclude this until we get feedback about large ARM runners
+            arch: arm64
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+#      - name: Import GPG key
+#        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
+#        id: import_gpg
+#        with:
+#          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+#          passphrase: ${{ secrets.PASSPHRASE }}
+
+      - name: Install dependencies (Linux only)
+        if: matrix.os == 'ubuntu-24.04'
+        run: sudo apt update && sudo apt install -y ${{ matrix.dependencies }}
+
+      - name: Install Go dependencies
+        run: go mod tidy
+
+      - name: Build binary
+        run: make ${{ matrix.build_target }} BINARY_VERSION="_${{ github.ref_name }}"
+
+      - name: Verify binary
+        run: make ${{ matrix.verify_target }} BINARY_VERSION="_${{ github.ref_name }}"
+
+      - name: Prepare release artifacts
+        id: prepare-release
+        run: |
+          MODULE_NAME=$(grep "^module" go.mod | awk -F'/' '{print $NF}')
+          VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')
+          BINARY="${MODULE_NAME}_v${VERSION}"
+          ARCHIVE="${MODULE_NAME}_${VERSION}_${{ matrix.os }}_${{ matrix.arch }}.zip"
+
+          # Create ZIP archive
+          zip ${ARCHIVE} ${BINARY}
+
+          echo "module_name=${MODULE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          echo "module_name=${MODULE_NAME}" >> "$GITHUB_ENV"
+          echo "version=${VERSION}" >> "$GITHUB_ENV"
+          echo "archive=${ARCHIVE}" >> "$GITHUB_ENV"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+        with:
+          name: ${{ env.module_name }}_${{ env.version }}_${{ matrix.os }}_${{ matrix.arch }}
+          retention-days: 5
+          path: |
+            ${{ env.archive }}
+
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-24.04
+    needs: build-artifact
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Download ZIP files
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          pattern: ${{ needs.build-artifact.outputs.module_name }}_${{ needs.build-artifact.outputs.version }}_*
+          path: ./release
+
+      - name: Generate SHA256SUMS
+        run: |
+          cd release
+          find . -type f -name "*.zip" -exec mv {} . \;
+          shasum -a 256 *.zip > ${{ needs.build-artifact.outputs.module_name }}_${{ needs.build-artifact.outputs.version }}_SHA256SUMS
+
+      - name: Sign SHA256SUMS
+        run: |
+          cd release
+          gpg --detach-sign ${{ needs.build-artifact.outputs.module_name }}_${{ needs.build-artifact.outputs.version }}_SHA256SUMS
+
+      - name: Release
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
+        with:
+          files: |
+            release/*.zip
+            terraform-registry-manifest.json
+            release/${{ needs.build-artifact.outputs.module_name }}_${{ needs.build-artifact.outputs.version }}_SHA256SUMS
+            release/${{ needs.build-artifact.outputs.module_name }}_${{ needs.build-artifact.outputs.version }}_SHA256SUMS.sig

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -4,22 +4,17 @@ on:
   push:
     branches:
       - "main"
+      - "TR6_adding_continuous_registry_deployment"
   pull_request:
 
 jobs:
-  check-run:
-    name: Check PR run
-    uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
-
   sast:
     name: SAST scan
-    runs-on: ubuntu-22.04
-    needs: check-run
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write
       security-events: write
-
     steps:
       - name: Check out repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -48,12 +43,10 @@ jobs:
 
   quality:
     name: Quality scan
-    runs-on: ubuntu-22.04
-    needs: check-run
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write
-
     steps:
       - name: Check out repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -72,3 +65,58 @@ jobs:
           args: >
             -Dsonar.organization=${{ github.repository_owner }}
             -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
+
+  docs:
+    name: Validate Docs
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    env:
+      CGO_ENABLED: 1
+      CGO_LDFLAGS: -lm
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: 'go.mod'
+
+      - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
+        with:
+          terraform_version: '1.9.2'
+          terraform_wrapper: false
+
+      - name: Install Go dependencies
+        run: go mod tidy
+
+      - name: Generate documentation
+        run: |
+          go generate ./...
+
+      - name: Git diff
+        run: |
+          git diff --compact-summary --exit-code examples docs || \
+            (echo; echo "Unexpected difference in directories [/examples, /docs] after code generation. Run 'go generate ./...' command and commit."; exit 1)
+
+  lint:
+    name: Run Linters
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run linters
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
+        with:
+          version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,59 +1,24 @@
-# Terraform Provider testing workflow.
 name: Tests
 
-# This GitHub action runs your tests for each pull request and push.
-# Optionally, you can turn it on using a schedule for regular testing.
 on:
   push:
     branches:
       - "main"
+      - "TR6_adding_continuous_registry_deployment"
   pull_request:
 
-# Testing only needs permissions to read the repository contents.
 permissions:
   contents: read
 
 env:
   CGO_ENABLED: 1
-  CGO_LDFLAGS: -lm
+  CGO_LDFLAGS: '-static -Wl,-unresolved-symbols=ignore-all'
+  CC: musl-gcc
 
 jobs:
-  # Ensure project builds before running testing matrix
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
-        with:
-          go-version-file: 'go.mod'
-      - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
-        with:
-          terraform_version: '1.9.2'
-          terraform_wrapper: false
-      - name: Install dependencies
-        run: go mod tidy
-      - name: Build binary
-        run: go build -v .
-      - name: Run linters
-        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
-        with:
-          version: latest
-      - name: Generate documentation
-        run: |
-          go get github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
-          go generate ./...
-      - name: Git diff
-        run: |
-          git diff --compact-summary --exit-code examples docs || \
-            (echo; echo "Unexpected difference in directories [/examples, /docs] after code generation. Run 'go generate ./...' command and commit."; exit 1)
-
-  # Run acceptance tests in a matrix with Terraform CLI versions
   acctest_tf:
     name: "Terraform: Provider Acceptance Tests"
-    needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       max-parallel: 1
@@ -68,15 +33,22 @@ jobs:
           - '1.9.*'
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version-file: 'go.mod'
+
       - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
-      - name: Install dependencies
-        run: go mod download
+
+      - name: Install Go dependencies
+        run: go mod tidy
+
+      - name: Install build dependencies
+        run: sudo apt update && sudo apt install musl-tools -y
+
       - name: Create bw client configuration file
         run: |
           echo 'BW_API_URL="${{ secrets.BW_API_URL }}"' >> .env.local.test
@@ -90,14 +62,14 @@ jobs:
           echo 'BW_ACCESS_TOKEN="${{ secrets.BW_ACCESS_TOKEN_NO_ACCESS }}"' >> .env.local.no.access
           echo 'BW_STATE_FILE=".bw-state-qa"' >> .env.local.test
           echo 'BW_STATE_FILE=".bw-state-qa-no-access"' >> .env.local.no.access
+
       - name: Run acceptance tests
         run: make testacc
 
-  # Run acceptance tests with OpenTofu CLI versions
   acctest_tofu:
     name: "OpenTofu: Provider Acceptance Tests"
     needs: acctest_tf
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       max-parallel: 1
@@ -110,15 +82,22 @@ jobs:
           - '1.8'
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version-file: 'go.mod'
+
       - uses: opentofu/setup-opentofu@ae80d4ecaab946d8f5ff18397fbf6d0686c6d46a # v1.0.3
         with:
           tofu_version: ${{ matrix.opentofu }}
           tofu_wrapper: false
-      - name: Install dependencies
-        run: go mod download
+
+      - name: Install Go dependencies
+        run: go mod tidy
+
+      - name: Install build dependencies
+        run: sudo apt update && sudo apt install musl-tools -y
+
       - name: Create bw client configuration file
         run: |
           echo 'BW_API_URL="${{ secrets.BW_API_URL }}"' >> .env.local.test
@@ -132,5 +111,6 @@ jobs:
           echo 'BW_ACCESS_TOKEN="${{ secrets.BW_ACCESS_TOKEN_NO_ACCESS }}"' >> .env.local.no.access
           echo 'BW_STATE_FILE=".bw-state-qa"' >> .env.local.test
           echo 'BW_STATE_FILE=".bw-state-qa-no-access"' >> .env.local.no.access
+
       - name: Run acceptance tests
         run: make testacc_tofu

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,13 +1,92 @@
-TEST?=./...
-GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
-OPENTOFU_PATH?=$$(which tofu)
+# Default test path and formatting
+TEST ?= ./...
+GOFMT_FILES ?= $(shell find . -name '*.go' |grep -v vendor)
+OPENTOFU_PATH ?= $(shell which tofu)
+
+# Extract binary name from go.mod
+BINARY_NAME?=$(shell grep "^module" go.mod | awk -F'/' '{print $$NF}')
+
+# Optional version tag for binary
+BINARY_VERSION ?= ''
+
+# Default build parameters
+PARAM_CC ?= musl-gcc
+PARAM_GOOS ?= linux
+PARAM_GOARCH ?= amd64
+PARAM_CGO_ENABLED ?= 1
+PARAM_CGO_LDFLAGS ?= '-s -w -static -Wl,-unresolved-symbols=ignore-all'
+PARAM_VERIFY ?= 'statically linked'
+
+# Setup default environment variables
+.PHONY: set-env
+set-env:
+	go env -w GOOS=$(PARAM_GOOS)
+	go env -w GOARCH=$(PARAM_GOARCH)
+	go env -w CGO_ENABLED=$(PARAM_CGO_ENABLED)
+
+# Setup linux environment variables
+.PHONY: set-env-linux
+set-env-linux: set-env
+	go env -w CC=$(PARAM_CC)
+	go env -w CGO_LDFLAGS=$(PARAM_CGO_LDFLAGS)
+
+# Build a static linux binary
+.PHONY: build-linux
+build-linux: set-env-linux
+	go build -v -o $(BINARY_NAME)$(BINARY_VERSION) .
+
+# Build statically binary for linux amd64
+.PHONY: build-linux-amd64
+build-linux-amd64:
+	$(MAKE) build-linux
+
+# Build statically binary for linux arm64
+.PHONY: build-linux-arm64
+build-linux-arm64:
+	$(MAKE) PARAM_GOARCH="arm64" build-linux
+
+# Build a macOS binary
+.PHONY: build-darwin
+build-darwin: set-env
+	go build -v -o $(BINARY_NAME)$(BINARY_VERSION) .
+
+# Build a macOS binary for amd64
+.PHONY: build-darwin-amd64
+build-darwin-amd64:
+	$(MAKE) PARAM_GOOS="darwin" build-darwin
+
+# Build a macOS binary for arm64
+.PHONY: build-darwin-arm64
+build-darwin-arm64:
+	$(MAKE) PARAM_GOOS="darwin" PARAM_GOARCH="arm64" build-darwin
+
+# Verify binary
+.PHONY: verify-binary
+verify-binary:
+	file $(BINARY_NAME)$(BINARY_VERSION) | grep -i $(PARAM_VERIFY)
+
+# Verify linux binary
+.PHONY: verify-binary-linux
+verify-binary-linux:
+	$(MAKE) verify-binary
+
+# Verify macOS binary amd64
+.PHONY: verify-binary-darwin-amd64
+verify-binary-darwin-amd64:
+	$(MAKE) PARAM_VERIFY="'executable x86_64'" verify-binary
+
+# Verify macOS binary arm64
+.PHONY: verify-binary-darwin-arm64
+verify-binary-darwin-arm64:
+	$(MAKE) PARAM_VERIFY="'executable arm64'" verify-binary
 
 default: testacc
 
 # Run acceptance tests
 .PHONY: testacc
 testacc:
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 10m
+	TF_ACC=1 \
+	go test $(TEST) -v $(TESTARGS) -timeout 10m
 
 # Run unit tests
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -15,14 +15,33 @@ If you wish to work on the provider, you'll first need [Go](http://www.golang.or
 
 ### Building The Provider
 
+#### Local Development
+
 1. Clone the repository
 2. Enter the repository directory
-3. Build the provider using the Go `install` command:
+3. Execute `go mod tidy` to install all dependencies
+4. Build the provider using the Go `install` command:
+    ```shell
+    go install .
+    ```
 
-```shell
-go install .
-```
-This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
+This will build a dynamically linked binary for the provider and puts it in the `$GOPATH/bin` directory.
+
+#### CGO and Statically linked Binaries
+
+This provider is using the official [`sdk-go`](https://github.com/bitwarden/sdk-go) from [Bitwarden](https://github.com/bitwarden).
+This dependency utilizes `CGO`.
+In order to build a statically linked binary for linux, the following build configuration is necessary:
+
+1. The library `musl-tools` needs to be available on the system
+2. The following environment variables need to be set:
+    ```bash
+    go env -w CGO_ENABLED="1"
+    go env -w CC="musl-gcc"
+    go env -w CGO_LDFLAGS="-static -Wl,-unresolved-symbols=ignore-all"
+    ```
+   
+Using this configuration, `go install .` and `go build` should generate statically linked binaries.
 
 ### Development Overrides
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ go 1.22.5
 require (
 	github.com/bitwarden/sdk-go v0.1.1
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.10.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
@@ -45,14 +46,12 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
-	github.com/hashicorp/terraform-plugin-docs v0.19.4 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
-	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
@@ -63,7 +62,6 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
-	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,7 +31,6 @@ github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZ
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -42,6 +41,8 @@ github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FM
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
+github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
+github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.5.0 h1:yEY4yhzCDuMGSv83oGxiBotRzhwhNr8VZyphhiu+mTU=
@@ -167,7 +168,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
@@ -276,7 +276,6 @@ google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWn
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "metadata": {
+    "protocol_versions": ["6.0"]
+  }
+}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,0 +1,8 @@
+//go:build tools
+
+package tools
+
+import (
+	// Documentation generation
+	_ "github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs"
+)


### PR DESCRIPTION
## 📔 Objective

This PR contains updated to our GitHUb Actions Workflows in preparation of the release of our terraform provider.
Example executions of the release-workflow triggered by pushing a tag can be found here:

* https://github.com/bitwarden/terraform-provider-bitwarden-sm/actions/runs/10576889905
* https://github.com/bitwarden/terraform-provider-bitwarden-sm/actions/runs/10577138150

We followed hashicorps documentation about the manual release preparation:
https://developer.hashicorp.com/terraform/registry/providers/publishing#manually-preparing-a-release

The following things are still open:

* we need to setup a signing key in order to sign the [hashes of our binaries](https://developer.hashicorp.com/terraform/registry/providers/publishing#signing-in)
* we need to decide if we can use large hosted runners in GitHub Actions in order to provide a native ubuntu environment to build arm64 binaries

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
