### PR TITLE
Fixed version extraction in repository-management workflow

### DIFF
--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Get current version
         id: current-version
         run: |
-          CURRENT_VERSION=$(grep 'ProviderVersion string =' version/version.go | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+(-pre)?)".*/\1/')
+          CURRENT_VERSION=$(grep 'ProviderVersion =' version/version.go | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+(-pre)?)".*/\1/')
           echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Verify and set input version
@@ -126,6 +126,10 @@ jobs:
                 ;;
             esac
             NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+
+            if [[ "$RELEASE_TYPE" == "pre-release" ]]; then
+              NEW_VERSION="$NEW_VERSION-pre"
+            fi
           fi
 
           echo "New version is $NEW_VERSION"


### PR DESCRIPTION
## 📔 Objective

The repository-management workflow contained a bug in the extraction of the current version before the version bump. This PR addresses this bug.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
