### PR TITLE
[BRE] Updated validation logic and job summary outputs

### DIFF
--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -39,12 +39,11 @@ jobs:
         env:
           NEW_VERSION: ${{ inputs.version_number_override }}
         run: |
-          SEMVER_REGEX="^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-pre)?$"
-
-          if [[ NEW_VERSION =~ $SEMVER_REGEX ]]; then
-            echo "NEW_VERSION is a valid semantic version."
+          SEMVER_REGEX="^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"
+          if [[ $NEW_VERSION =~ $SEMVER_REGEX ]]; then
+            echo "New version [$NEW_VERSION] is a valid semantic version."
           else
-            echo "NEW_VERSION is not a valid semantic version."
+            echo "New version [$NEW_VERSION] is not a valid semantic version."
             exit 1
           fi
 
@@ -87,26 +86,33 @@ jobs:
       - name: Get current version
         id: current-version
         run: |
-          CURRENT_VERSION=$(grep 'ProviderVersion =' version/version.go | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+(-pre)?)".*/\1/')
+          CURRENT_VERSION=$(grep 'ProviderVersion =' version/version.go | cut -f2 -d '=' | grep -Eo '"(.*)"' | tr -d '"')
+          if [[ -z "$CURRENT_VERSION" ]]; then
+            echo "Failed to extract current version from version/version.go" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "Current version: [$CURRENT_VERSION]"
           echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Verify and set input version
+        id: verify-input-version
         if: ${{ inputs.version_number_override != '' }}
         env:
           CURRENT_VERSION: ${{ steps.current-version.outputs.version }}
           NEW_VERSION: ${{ inputs.version_number_override }}
+          RELEASE_TYPE: ${{ inputs.release_type }}
         run: |
           # Error if version has not changed.
           if [[ "$NEW_VERSION" == "$CURRENT_VERSION" ]]; then
-            echo "Specified override version is the same as the current version." >> "$GITHUB_STEP_SUMMARY"
+            echo "Specified override version [$NEW_VERSION] is the same as the current version [$CURRENT_VERSION]." >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
 
           # Check if version is newer.
           if printf '%s\n' "${CURRENT_VERSION}" "${NEW_VERSION}" | sort -C -V; then
-            echo "Version is newer than the current version."
+            echo "New version [$NEW_VERSION] is newer than the current version [$CURRENT_VERSION]."
           else
-            echo "Version is older than the current version." >> "$GITHUB_STEP_SUMMARY"
+            echo "New version [$NEW_VERSION] is older than the current version [$CURRENT_VERSION]." >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
 
@@ -114,7 +120,7 @@ jobs:
             NEW_VERSION="$NEW_VERSION-pre"
           fi
 
-          echo "New version is $NEW_VERSION"
+          echo "New version: [$NEW_VERSION]"
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Calculate next release version
@@ -151,19 +157,19 @@ jobs:
             fi
           fi
 
-          echo "New version is $NEW_VERSION"
+          echo "New version: [$NEW_VERSION]"
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Update provider version in version.go
         env:
-          NEW_VERSION: ${{ steps.calculate-next-version.outputs.new_version }}
+          NEW_VERSION: ${{ steps.verify-input-version.outputs.new_version || steps.calculate-next-version.outputs.new_version }}
         run: |
           sed -i "s/ProviderVersion = \".*\"/ProviderVersion = \"$NEW_VERSION\"/" version/version.go
 
       - name: Commit and push version update
         env:
-          NEW_VERSION: ${{ steps.calculate-next-version.outputs.new_version }}
+          NEW_VERSION: ${{ steps.verify-input-version.outputs.new_version || steps.calculate-next-version.outputs.new_version }}
         run: |
           git add version/version.go
-          git commit -m "Update provider version to $NEW_VERSION"
+          git commit -m "Update provider version to [$NEW_VERSION]"
           git push origin main


### PR DESCRIPTION
## 📔 Objective

Workflow was [failing](https://github.com/bitwarden/terraform-provider-bitwarden-secrets/actions/runs/23920500018) when releasing 1.0.0

- corrected variables missing `$`s
- added variable values to step summary outputs
- updated the `SEMVER_REGEX` to reject version overrides with `-pre` suffix since `verify-input-version` step auto adds `-pre` when `pre-release` type is selected
- added logic to gracefully fail if version is empty in `version.go`


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
