### PR TITLE
fix: remove step interval for renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>bitwarden/renovate-config"],
   "timezone": "America/Chicago",
-  "schedule": ["* 0-4 1-7 2/2 1"],
+  "schedule": ["* 6 1-7 2,4,6,8,10,12 1"],
   "enabledManagers": ["gomod", "github-actions"],
   "constraints": {
     "go": "1.25"


### PR DESCRIPTION
## 📔 Objective

> Use strict cron syntax by removing step interval in renovate config that is causing upstream issues with scheduling

