### PR TITLE
[BRE-2068] Update release GPG secrets to gh-deploy keyvault

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,8 @@ jobs:
         id: get-kv-secrets
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
-          keyvault: gh-tf-provider-bw-secret
-          secrets: "GPG-PRIVATE-KEY,GPG-PASSPHRASE,GPG-KEY-ID"
+          keyvault: gh-deploy
+          secrets: "TF-PROVIDER-BW-SECRET-GPG-PRIVATE-KEY,TF-PROVIDER-BW-SECRET-GPG-PASSPHRASE,TF-PROVIDER-BW-SECRET-GPG-KEY-ID"
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
@@ -64,8 +64,8 @@ jobs:
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
-          gpg_private_key: ${{ steps.get-kv-secrets.outputs.GPG-PRIVATE-KEY }}
-          passphrase: ${{ steps.get-kv-secrets.outputs.GPG-PASSPHRASE }}
+          gpg_private_key: ${{ steps.get-kv-secrets.outputs.TF-PROVIDER-BW-SECRET-GPG-PRIVATE-KEY }}
+          passphrase: ${{ steps.get-kv-secrets.outputs.TF-PROVIDER-BW-SECRET-GPG-PASSPHRASE }}
 
       - name: Prepare Manifest File
         id: manifest
@@ -81,7 +81,7 @@ jobs:
 
       - name: Sign Checksum File
         env:
-          GPG_KEY_ID: ${{ steps.get-kv-secrets.outputs.GPG-KEY-ID }}
+          GPG_KEY_ID: ${{ steps.get-kv-secrets.outputs.TF-PROVIDER-BW-SECRET-GPG-KEY-ID }}
           CHECKSUM_FILE: ${{ steps.checksum.outputs.checksum_file }}
         run: |
           gpg --detach-sign --local-user "${GPG_KEY_ID}" --output "${CHECKSUM_FILE}.sig" "${CHECKSUM_FILE}"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-2068

## 📔 Objective

Updating vault and secret references in release workflow after migration to `gh-deploy` vault in AKV.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
